### PR TITLE
Add the Google Play badge to the Clients page

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -10,11 +10,13 @@ Do you have a client that interfaces with Jellyfin and want to see it listed her
 
 ### Jellyfin for Android
 
-The official Jellyfin Android app supporting Android 4+.
+The official Jellyfin Android app supporting Android 5+.
 
 **Status:** ⭐ In Beta release
 
 **Links:**
+
+<a href='https://play.google.com/store/apps/details?id=org.jellyfin.mobile&utm_source=docs&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="200"/></a>
 
 * [GitHub](https://github.com/jellyfin/jellyfin-android)
 * [Binary repository](https://repo.jellyfin.org/releases/client/android)


### PR DESCRIPTION
Adds the "Get it on Google Play" official badge, with markup generated by the badge generator.